### PR TITLE
Added default extension files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@
 * You can test that everything is working in your project by selecting the `Run`menu, then `Run As` and `Ghidra`.
 * A new instance if Ghidra should be loaded, if you import an NSIS executable file, should see the 'Nsis' Format suggestion in the first entry of the import dialog.
 
+# Building with Gradle
+
+* Ensure the `GHIDRA_INSTALL_DIR` environment variable is set to root directory of the Ghidra installation.
+* In the project root run `gradle buildExtension`.
+* Upon completion a distributable zip file will be located in the dist directory and may be installed through Ghidra's user interface.
+
 # Updating The Disassembler Specification
 
-* If a change is made to Nsis.slaspec, it needs to be reprocessed by the sleight utility. Example commande: `<ghidra installer folder>/support/sleigh data/languages/Nsis.slaspec`
+* If a change is made to Nsis.slaspec, it needs to be reprocessed by the sleight utility. Example command: `<ghidra installer folder>/support/sleigh data/languages/Nsis.slaspec`
 * The newly generated files then need to be moved to the `<ghidra install folder>/Ghidra/Processors/Nsis/`folder.
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,35 @@
+// Builds a Ghidra Extension for a given Ghidra installation.
+//
+// An absolute path to the Ghidra installation directory must be supplied either by setting the 
+// GHIDRA_INSTALL_DIR environment variable or Gradle project property:
+//
+//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra> 
+//     > gradle
+//
+//         or
+//
+//     > gradle -PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
+//
+// Gradle should be invoked from the directory of the project to build.  Please see the
+// application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
+// for the correction version of Gradle to use for the Ghidra installation you specify.
+
+//----------------------START "DO NOT MODIFY" SECTION------------------------------
+def ghidraInstallDir
+
+if (System.env.GHIDRA_INSTALL_DIR) {
+	ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
+}
+else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
+	ghidraInstallDir = project.getProperty("GHIDRA_INSTALL_DIR")
+}
+
+if (ghidraInstallDir) {
+	apply from: new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
+}
+else {
+	throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
+}
+//----------------------END "DO NOT MODIFY" SECTION-------------------------------
+
+sourceSets.main.java.srcDirs += 'Nsis/src'

--- a/extension.properties
+++ b/extension.properties
@@ -1,0 +1,5 @@
+name=@extname@
+description=The extension description can be customized by editing the extension.properties file.
+author=
+createdOn=
+version=@extversion@


### PR DESCRIPTION
These files are from the [Ghidra Skeleton extension](https://github.com/NationalSecurityAgency/ghidra/tree/master/GhidraBuild/Skeleton) and allow building without Eclipse. 

The Module.manifest file is required to be present or it is not possible to fully install the extension via Ghidra's `Install Extensions`.

- [ ] Tests pass **Not applicable**
- Appropriate changes to README are included in PR

Edit: This should be a draft. The data folder isn't placed in the correct path in the installation zip.