### PR TITLE
Nsis header loader

### DIFF
--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -62,7 +62,7 @@ public class NsisLoader extends PeLoader {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
 		NsisExecutable ne = NsisExecutable.createNsisExecutable(
 				RethrowContinuesFactory.INSTANCE, provider, SectionLayout.FILE);
-		if (ne.getHeaderOffset() != 0) {
+		if (ne.getHeaderOffset() != -1) {
 			LoadSpec my_spec = new LoadSpec(this, 0x400000,
 					new LanguageCompilerSpecPair("Nsis:LE:32:default",
 							"default"),

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -36,19 +36,17 @@ public class NsisExecutable {
 
 	private void findHeaderOffset() {
 		if (this.header_offset == -1) {
-			for (long offset = 0; offset
-					+ NsisConstants.NSIS_MAGIC.length <= this
-							.getFileLength(); offset++) {
-				try {
+			try {
+				for (long offset = 0; offset + NsisConstants.NSIS_MAGIC.length <= reader.length(); offset++) {
 					byte[] content = reader.readByteArray(offset,
 							NsisConstants.NSIS_MAGIC.length);
 					if (Arrays.equals(NsisConstants.NSIS_MAGIC, content)) {
 						this.header_offset = offset;
 						return;
 					}
-				} catch (IOException e) {
-					return;
 				}
+			} catch (IOException e) {
+					return;
 			}
 		}
 	}

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -1,0 +1,63 @@
+package nsis.file;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import generic.continues.GenericFactory;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.format.FactoryBundledWithBinaryReader;
+import ghidra.app.util.bin.format.pe.PortableExecutable.SectionLayout;
+
+public class NsisExecutable {
+
+	public static final String NAME = "NULLSOFT_SCRIPTABLE_INSTALLER_SYSTEM";
+	
+	private FactoryBundledWithBinaryReader reader;
+	private long header_offset;
+	
+	public NsisExecutable() {}
+	
+	public static NsisExecutable createNsisExecutable(GenericFactory factory, ByteProvider bp, SectionLayout layout) {
+		NsisExecutable nsisExecutable = (NsisExecutable) factory.create(NsisExecutable.class);
+		nsisExecutable.initNsisExecutable(factory, bp, layout);
+		return nsisExecutable;
+	}
+	
+	private void initNsisExecutable(GenericFactory factory, ByteProvider bp, SectionLayout layout) {
+		this.reader = new FactoryBundledWithBinaryReader(factory, bp, true);
+		this.header_offset = -1;
+		findHeaderOffset();
+		//TODO Init sections and headers
+	}
+	
+	private void findHeaderOffset() {
+		if(this.header_offset == -1) {
+			for(long offset = 0; offset + NsisConstants.NSIS_MAGIC.length <= this.getFileLength(); offset++) {
+				try {
+					byte[] content = reader.readByteArray(offset, NsisConstants.NSIS_MAGIC.length);
+					if(Arrays.equals(NsisConstants.NSIS_MAGIC, content)) {
+						this.header_offset = offset;
+						return;
+					}
+				} catch (IOException e) {
+					return;
+				}
+			}
+		}
+	}
+	
+	public long getHeaderOffset() {
+		return this.header_offset;
+	}
+	
+	public long getFileLength() {
+		if(reader != null) {
+			try {
+				return reader.length();
+			} catch (IOException e) {
+				return 0;
+			}
+		}
+		return 0;
+	}
+}

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -19,7 +19,7 @@ public class NsisExecutable {
 	}
 
 	public static NsisExecutable createNsisExecutable(GenericFactory factory,
-			ByteProvider bp, SectionLayout layout) {
+			ByteProvider bp, SectionLayout layout) throws IOException {
 		NsisExecutable nsisExecutable = (NsisExecutable) factory
 				.create(NsisExecutable.class);
 		nsisExecutable.initNsisExecutable(factory, bp, layout);
@@ -27,26 +27,24 @@ public class NsisExecutable {
 	}
 
 	private void initNsisExecutable(GenericFactory factory, ByteProvider bp,
-			SectionLayout layout) {
+			SectionLayout layout) throws IOException {
 		this.reader = new FactoryBundledWithBinaryReader(factory, bp, true);
 		this.header_offset = -1;
 		findHeaderOffset();
 		// TODO Init sections and headers
 	}
 
-	private void findHeaderOffset() {
+	private void findHeaderOffset() throws IOException {
 		if (this.header_offset == -1) {
-			try {
-				for (long offset = 0; offset + NsisConstants.NSIS_MAGIC.length <= reader.length(); offset++) {
-					byte[] content = reader.readByteArray(offset,
-							NsisConstants.NSIS_MAGIC.length);
-					if (Arrays.equals(NsisConstants.NSIS_MAGIC, content)) {
-						this.header_offset = offset;
-						return;
-					}
-				}
-			} catch (IOException e) {
+			for (long offset = 0; offset
+					+ NsisConstants.NSIS_MAGIC.length <= reader
+							.length(); offset++) {
+				byte[] content = reader.readByteArray(offset,
+						NsisConstants.NSIS_MAGIC.length);
+				if (Arrays.equals(NsisConstants.NSIS_MAGIC, content)) {
+					this.header_offset = offset;
 					return;
+				}
 			}
 		}
 	}

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -57,14 +57,4 @@ public class NsisExecutable {
 		return this.header_offset;
 	}
 
-	public long getFileLength() {
-		if (reader != null) {
-			try {
-				return reader.length();
-			} catch (IOException e) {
-				return 0;
-			}
-		}
-		return 0;
-	}
 }

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -11,31 +11,38 @@ import ghidra.app.util.bin.format.pe.PortableExecutable.SectionLayout;
 public class NsisExecutable {
 
 	public static final String NAME = "NULLSOFT_SCRIPTABLE_INSTALLER_SYSTEM";
-	
+
 	private FactoryBundledWithBinaryReader reader;
 	private long header_offset;
-	
-	public NsisExecutable() {}
-	
-	public static NsisExecutable createNsisExecutable(GenericFactory factory, ByteProvider bp, SectionLayout layout) {
-		NsisExecutable nsisExecutable = (NsisExecutable) factory.create(NsisExecutable.class);
+
+	public NsisExecutable() {
+	}
+
+	public static NsisExecutable createNsisExecutable(GenericFactory factory,
+			ByteProvider bp, SectionLayout layout) {
+		NsisExecutable nsisExecutable = (NsisExecutable) factory
+				.create(NsisExecutable.class);
 		nsisExecutable.initNsisExecutable(factory, bp, layout);
 		return nsisExecutable;
 	}
-	
-	private void initNsisExecutable(GenericFactory factory, ByteProvider bp, SectionLayout layout) {
+
+	private void initNsisExecutable(GenericFactory factory, ByteProvider bp,
+			SectionLayout layout) {
 		this.reader = new FactoryBundledWithBinaryReader(factory, bp, true);
 		this.header_offset = -1;
 		findHeaderOffset();
-		//TODO Init sections and headers
+		// TODO Init sections and headers
 	}
-	
+
 	private void findHeaderOffset() {
-		if(this.header_offset == -1) {
-			for(long offset = 0; offset + NsisConstants.NSIS_MAGIC.length <= this.getFileLength(); offset++) {
+		if (this.header_offset == -1) {
+			for (long offset = 0; offset
+					+ NsisConstants.NSIS_MAGIC.length <= this
+							.getFileLength(); offset++) {
 				try {
-					byte[] content = reader.readByteArray(offset, NsisConstants.NSIS_MAGIC.length);
-					if(Arrays.equals(NsisConstants.NSIS_MAGIC, content)) {
+					byte[] content = reader.readByteArray(offset,
+							NsisConstants.NSIS_MAGIC.length);
+					if (Arrays.equals(NsisConstants.NSIS_MAGIC, content)) {
 						this.header_offset = offset;
 						return;
 					}
@@ -45,13 +52,13 @@ public class NsisExecutable {
 			}
 		}
 	}
-	
+
 	public long getHeaderOffset() {
 		return this.header_offset;
 	}
-	
+
 	public long getFileLength() {
-		if(reader != null) {
+		if (reader != null) {
 			try {
 				return reader.length();
 			} catch (IOException e) {

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -8,6 +8,8 @@ import ghidra.app.util.bin.format.pe.PortableExecutable.SectionLayout;
 import nsis.file.NsisExecutable;
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+
 public class NsisExecutableTest {
 
 	private byte[] mockFile = { (byte) 0xef, (byte) 0xef, (byte) 0xef,
@@ -15,7 +17,7 @@ public class NsisExecutableTest {
 			'f', 't', 'I', 'n', 's', 't' };
 
 	@Test
-	public void testNsisCreation() {
+	public void testNsisCreation() throws IOException {
 		ByteArrayProvider bp = new ByteArrayProvider(this.mockFile);
 		NsisExecutable ne = NsisExecutable.createNsisExecutable(
 				RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -23,13 +23,4 @@ public class NsisExecutableTest {
 		assertEquals((long) 2, headerOffset);
 	}
 
-	@Test
-	public void testFileLength() {
-		ByteArrayProvider bp = new ByteArrayProvider(this.mockFile);
-		NsisExecutable ne = NsisExecutable.createNsisExecutable(
-				RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
-		long fileLength = ne.getFileLength();
-		assertEquals((long) 18, fileLength);
-	}
-
 }

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -1,0 +1,31 @@
+package nsis.tests;
+
+import org.junit.Test;
+
+import generic.continues.RethrowContinuesFactory;
+import ghidra.app.util.bin.ByteArrayProvider;
+import ghidra.app.util.bin.format.pe.PortableExecutable.SectionLayout;
+import nsis.file.NsisExecutable;
+import static org.junit.Assert.*;
+
+public class NsisExecutableTest {
+
+	private byte[] mockFile = { (byte) 0xef, (byte) 0xef, (byte) 0xef, (byte) 0xbe, (byte) 0xad, (byte) 0xde, 'N', 'u', 'l', 'l', 's', 'o', 'f', 't', 'I', 'n', 's', 't' };
+	
+	@Test
+	public void testHeaderOffset() {
+		ByteArrayProvider bp = new ByteArrayProvider(this.mockFile);
+		NsisExecutable ne = NsisExecutable.createNsisExecutable(RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
+		long headerOffset = ne.getHeaderOffset();
+		assertEquals((long)2, headerOffset);
+	}
+	
+	@Test
+	public void testFileLength() {
+		ByteArrayProvider bp = new ByteArrayProvider(this.mockFile);
+		NsisExecutable ne = NsisExecutable.createNsisExecutable(RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
+		long fileLength = ne.getFileLength();
+		assertEquals((long)18, fileLength);
+	}
+	
+}

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -10,22 +10,26 @@ import static org.junit.Assert.*;
 
 public class NsisExecutableTest {
 
-	private byte[] mockFile = { (byte) 0xef, (byte) 0xef, (byte) 0xef, (byte) 0xbe, (byte) 0xad, (byte) 0xde, 'N', 'u', 'l', 'l', 's', 'o', 'f', 't', 'I', 'n', 's', 't' };
-	
+	private byte[] mockFile = { (byte) 0xef, (byte) 0xef, (byte) 0xef,
+			(byte) 0xbe, (byte) 0xad, (byte) 0xde, 'N', 'u', 'l', 'l', 's', 'o',
+			'f', 't', 'I', 'n', 's', 't' };
+
 	@Test
-	public void testHeaderOffset() {
+	public void testNsisCreation() {
 		ByteArrayProvider bp = new ByteArrayProvider(this.mockFile);
-		NsisExecutable ne = NsisExecutable.createNsisExecutable(RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
+		NsisExecutable ne = NsisExecutable.createNsisExecutable(
+				RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
 		long headerOffset = ne.getHeaderOffset();
-		assertEquals((long)2, headerOffset);
+		assertEquals((long) 2, headerOffset);
 	}
-	
+
 	@Test
 	public void testFileLength() {
 		ByteArrayProvider bp = new ByteArrayProvider(this.mockFile);
-		NsisExecutable ne = NsisExecutable.createNsisExecutable(RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
+		NsisExecutable ne = NsisExecutable.createNsisExecutable(
+				RethrowContinuesFactory.INSTANCE, bp, SectionLayout.FILE);
 		long fileLength = ne.getFileLength();
-		assertEquals((long)18, fileLength);
+		assertEquals((long) 18, fileLength);
 	}
-	
+
 }


### PR DESCRIPTION
Fixes #5

- [ X] Tests pass
Tests can be run in eclipse with Run -> Run As -> Junit. Those tests will be integrated in Gradle in the next PR. 

After discussion with @rossgibb , it was decided to not use the entry point of the PE file to locate the NSIS header because in some cases the header could be located before. So it iterates the bytes and uses the first offset is finds that corresponds to the NSIS Magic. 