### PR TITLE
Renamed NsisScriptHeadet to NsisFirstHeader

### DIFF
--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -50,7 +50,7 @@ import ghidra.util.task.TaskMonitor;
 import nsis.file.NsisExecutable;
 import nsis.format.InvalidFormatException;
 import nsis.format.NsisBlockHeader;
-import nsis.format.NsisScriptHeader;
+import nsis.format.NsisFirstHeader;
 
 public class NsisLoader extends AbstractLibrarySupportLoader {
 
@@ -65,7 +65,8 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
 		try {
-			NsisExecutable ne = NsisExecutable.createNsisExecutable(RethrowContinuesFactory.INSTANCE, provider);
+			NsisExecutable ne = NsisExecutable
+					.createNsisExecutable(RethrowContinuesFactory.INSTANCE, provider);
 			LoadSpec my_spec = new LoadSpec(this, 0x400000,
 					new LanguageCompilerSpecPair("Nsis:LE:32:default", "default"), true);
 			loadSpecs.add(my_spec);
@@ -82,8 +83,8 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			throws CancelledException, IOException {
 		try {
 			GenericFactory factory = MessageLogContinuesFactory.create(log);
-			NsisExecutable ne = NsisExecutable.createInitializeNsisExecutable(factory,
-					provider, SectionLayout.FILE);
+			NsisExecutable ne = NsisExecutable.createInitializeNsisExecutable(factory, provider,
+					SectionLayout.FILE);
 			long scriptHeaderOffset = ne.getHeaderOffset();
 
 			Address scriptHeaderAddress = program.getAddressFactory().getDefaultAddressSpace()
@@ -91,12 +92,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 
 			try (InputStream headerInputStream = provider.getInputStream(scriptHeaderOffset)) {
 				initScriptHeader(headerInputStream, scriptHeaderAddress, program,
-						ne.getHeaderDataType(), monitor, NsisScriptHeader.getHeaderSize());
+						ne.getHeaderDataType(), monitor, NsisFirstHeader.getHeaderSize());
 			}
 
 			try (InputStream bodyInputStream = ne.getDecompressedInputStream()) {
 				Address blockHeadersStartingAddress = scriptHeaderAddress
-						.add(NsisScriptHeader.getHeaderSize());
+						.add(NsisFirstHeader.getHeaderSize());
 				initBlockHeaders(bodyInputStream, blockHeadersStartingAddress, program,
 						ne.getBlockHeaderDataType(), monitor, NsisBlockHeader.getHeaderSize());
 			}

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import com.google.common.primitives.Bytes;
 
 import generic.continues.GenericFactory;
-import generic.continues.RethrowContinuesFactory;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.bin.ByteProviderWrapper;
@@ -21,7 +20,7 @@ import nsis.compression.NsisLZMAProvider;
 import nsis.compression.NsisUncompressedProvider;
 import nsis.format.InvalidFormatException;
 import nsis.format.NsisBlockHeader;
-import nsis.format.NsisScriptHeader;
+import nsis.format.NsisFirstHeader;
 
 /**
  * 
@@ -35,7 +34,7 @@ public class NsisExecutable {
 
 	private BinaryReader reader;
 	private NsisDecompressionProvider decompressionProvider;
-	private NsisScriptHeader scriptHeader;
+	private NsisFirstHeader scriptHeader;
 	private NsisBlockHeader blockHeader;
 	private long headerOffset;
 
@@ -57,21 +56,24 @@ public class NsisExecutable {
 	 * @throws InvalidFormatException
 	 */
 	public static NsisExecutable createInitializeNsisExecutable(GenericFactory factory,
-			ByteProvider bp, SectionLayout layout)
-			throws IOException, InvalidFormatException {
+			ByteProvider bp, SectionLayout layout) throws IOException, InvalidFormatException {
 		NsisExecutable nsisExecutable = NsisExecutable.createNsisExecutable(factory, bp);
 		nsisExecutable.initNsisExecutable(factory);
 		return nsisExecutable;
 	}
-	
+
 	/**
-	 * Creates a Nsis Executable object, sets the reader and the offset parameter. To create and initialize a Nsis Executable object, use createInitializeNsisExecutable.
+	 * Creates a Nsis Executable object, sets the reader and the offset parameter.
+	 * To create and initialize a Nsis Executable object, use
+	 * createInitializeNsisExecutable.
+	 * 
 	 * @param factory
 	 * @param bp
 	 * @throws IOException
 	 * @throws InvalidFormatException
 	 */
-	public static NsisExecutable createNsisExecutable(GenericFactory factory, ByteProvider bp) throws IOException, InvalidFormatException {
+	public static NsisExecutable createNsisExecutable(GenericFactory factory, ByteProvider bp)
+			throws IOException, InvalidFormatException {
 		NsisExecutable nsisExecutable = (NsisExecutable) factory.create(NsisExecutable.class);
 		nsisExecutable.reader = new FactoryBundledWithBinaryReader(factory, bp,
 				NsisConstants.IS_LITTLE_ENDIAN);
@@ -83,9 +85,11 @@ public class NsisExecutable {
 			throws IOException, InvalidFormatException {
 		initScriptHeader();
 		this.decompressionProvider = getDecompressionProvider();
-		try(InputStream decompressesdStream = this.getDecompressedInputStream()){
-			ByteProvider blockDataByteProvider = new InputStreamByteProvider(decompressesdStream, this.scriptHeader.inflatedHeaderSize);
-			BinaryReader blockReader = new FactoryBundledWithBinaryReader(factory, blockDataByteProvider, NsisConstants.IS_LITTLE_ENDIAN);
+		try (InputStream decompressesdStream = this.getDecompressedInputStream()) {
+			ByteProvider blockDataByteProvider = new InputStreamByteProvider(decompressesdStream,
+					this.scriptHeader.inflatedHeaderSize);
+			BinaryReader blockReader = new FactoryBundledWithBinaryReader(factory,
+					blockDataByteProvider, NsisConstants.IS_LITTLE_ENDIAN);
 			this.blockHeader = new NsisBlockHeader(blockReader);
 		}
 	}
@@ -111,7 +115,7 @@ public class NsisExecutable {
 	 */
 	private void initScriptHeader() throws IOException, InvalidFormatException {
 		this.reader.setPointerIndex(this.headerOffset);
-		this.scriptHeader = new NsisScriptHeader(this.reader);
+		this.scriptHeader = new NsisFirstHeader(this.reader);
 	}
 
 	/**
@@ -185,7 +189,7 @@ public class NsisExecutable {
 	public DataType getHeaderDataType() {
 		return this.scriptHeader.toDataType();
 	}
-  
+
 	public DataType getBlockHeaderDataType() {
 		return this.blockHeader.toDataType();
 	}

--- a/nsis/src/nsis/format/NsisFirstHeader.java
+++ b/nsis/src/nsis/format/NsisFirstHeader.java
@@ -10,7 +10,7 @@ import ghidra.program.model.data.Structure;
 import ghidra.program.model.data.StructureDataType;
 import nsis.file.NsisConstants;
 
-public class NsisScriptHeader implements StructConverter {
+public class NsisFirstHeader implements StructConverter {
 	public final int flags;
 	private byte[] siginfo;
 	private byte[] magic;
@@ -35,7 +35,7 @@ public class NsisScriptHeader implements StructConverter {
 				"If the most significant bit is set, the following data is compressed");
 	}
 
-	public NsisScriptHeader(BinaryReader reader) throws IOException, InvalidFormatException {
+	public NsisFirstHeader(BinaryReader reader) throws IOException, InvalidFormatException {
 		this.flags = reader.readNextInt();
 		this.siginfo = reader.readNextByteArray(NsisConstants.NSIS_SIGINFO.length);
 		this.magic = reader.readNextByteArray(NsisConstants.NSIS_MAGIC.length);


### PR DESCRIPTION
Since we want to follow the Nsis spec and there are two headers (first header and header structures), I thought it would be a good idea to rename script header to first header before adding the header implementation. It will be less confusing

- [ x] Tests pass

