### PR TITLE
Clean NsisLoader

### DIFF
--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -128,13 +128,13 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			DataType dataType, TaskMonitor monitor, int size)
 			throws MemoryConflictException, AddressOverflowException, CancelledException,
 			DuplicateNameException, LockException, CodeUnitInsertionException {
-		Memory memory = program.getMemory();
-		MemoryBlock firstHeaderBlock = memory.createInitializedBlock(".first_header", startingAddr,
-				is, size, monitor, false);
-		firstHeaderBlock.setRead(true);
-		firstHeaderBlock.setWrite(false);
-		firstHeaderBlock.setExecute(false);
 
+		String blockName = ".first_header";
+		boolean readPermission = true;
+		boolean writePermission = false;
+		boolean executePermission = false;
+		createGhidraMemoryBlock(is, startingAddr, program, monitor, size, blockName, readPermission,
+				writePermission, executePermission);
 		createData(program, startingAddr, dataType);
 	}
 
@@ -160,6 +160,38 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	}
 
 	/**
+	 * 
+	 * Initializes a memory block in Ghidra with the given permissions
+	 * 
+	 * @param is                InputStream of the data
+	 * @param startingAddr
+	 * @param program
+	 * @param monitor
+	 * @param size
+	 * @param blockName
+	 * @param readPermission
+	 * @param writePermission
+	 * @param executePermission
+	 * @throws DuplicateNameException
+	 * @throws CancelledException
+	 * @throws AddressOverflowException
+	 * @throws MemoryConflictException
+	 * @throws LockException
+	 */
+	private void createGhidraMemoryBlock(InputStream is, Address startingAddr, Program program,
+			TaskMonitor monitor, int size, String blockName, boolean readPermission,
+			boolean writePermission, boolean executePermission)
+			throws LockException, MemoryConflictException, AddressOverflowException,
+			CancelledException, DuplicateNameException {
+		Memory memory = program.getMemory();
+		MemoryBlock firstHeaderBlock = memory.createInitializedBlock(blockName, startingAddr, is,
+				size, monitor, /* Overlay */ false);
+		firstHeaderBlock.setRead(readPermission);
+		firstHeaderBlock.setWrite(writePermission);
+		firstHeaderBlock.setExecute(executePermission);
+	}
+
+	/**
 	 * Initializes the common header and adds them to the "Program Trees" view in
 	 * Ghidra.
 	 * 
@@ -176,16 +208,15 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	 */
 	private void initCommonHeader(InputStream is, Address startingAddr, Program program,
 			DataType dataType, TaskMonitor monitor, int size)
-			throws IOException, LockException, DuplicateNameException, MemoryConflictException,
-			AddressOverflowException, CancelledException, CodeUnitInsertionException {
-		Memory memory = program.getMemory();
-		MemoryBlock blockHeadersBlock = memory.createInitializedBlock(".common_header",
-				startingAddr, is, size, monitor, false);
+			throws LockException, MemoryConflictException, AddressOverflowException,
+			CancelledException, DuplicateNameException, CodeUnitInsertionException {
 
-		blockHeadersBlock.setRead(true);
-		blockHeadersBlock.setWrite(false);
-		blockHeadersBlock.setExecute(false);
-
+		String blockName = ".common_header";
+		boolean readPermission = true;
+		boolean writePermission = false;
+		boolean executePermission = false;
+		createGhidraMemoryBlock(is, startingAddr, program, monitor, size, blockName, readPermission,
+				writePermission, executePermission);
 		createData(program, startingAddr, dataType);
 	}
 }

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -91,15 +91,13 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 					.getAddress(scriptHeaderOffset);
 
 			try (InputStream headerInputStream = provider.getInputStream(scriptHeaderOffset)) {
-				initFirstHeader(headerInputStream, firstHeaderAddress, program,
-						ne.getHeaderDataType(), monitor, NsisFirstHeader.getHeaderSize());
+				initFirstHeader(headerInputStream, firstHeaderAddress, program, monitor);
 			}
 
 			try (InputStream bodyInputStream = ne.getDecompressedInputStream()) {
 				Address commonHeaderAddress = firstHeaderAddress
 						.add(NsisFirstHeader.getHeaderSize());
-				initCommonHeader(bodyInputStream, commonHeaderAddress, program,
-						ne.getCommonHeaderDataType(), monitor, NsisCommonHeader.getHeaderSize());
+				initCommonHeader(bodyInputStream, commonHeaderAddress, program, monitor);
 			}
 
 		} catch (Exception e) {
@@ -125,17 +123,16 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	 * @throws CodeUnitInsertionException
 	 */
 	private void initFirstHeader(InputStream is, Address startingAddr, Program program,
-			DataType dataType, TaskMonitor monitor, int size)
-			throws MemoryConflictException, AddressOverflowException, CancelledException,
-			DuplicateNameException, LockException, CodeUnitInsertionException {
+			TaskMonitor monitor) throws MemoryConflictException, AddressOverflowException,
+			CancelledException, DuplicateNameException, LockException, CodeUnitInsertionException {
 
 		String blockName = ".first_header";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
-		createGhidraMemoryBlock(is, startingAddr, program, monitor, size, blockName, readPermission,
-				writePermission, executePermission);
-		createData(program, startingAddr, dataType);
+		createGhidraMemoryBlock(is, startingAddr, program, monitor, NsisFirstHeader.getHeaderSize(),
+				blockName, readPermission, writePermission, executePermission);
+		createData(program, startingAddr, NsisFirstHeader.STRUCTURE);
 	}
 
 	/**
@@ -207,7 +204,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	 * @throws CodeUnitInsertionException
 	 */
 	private void initCommonHeader(InputStream is, Address startingAddr, Program program,
-			DataType dataType, TaskMonitor monitor, int size)
+			TaskMonitor monitor)
 			throws LockException, MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException, CodeUnitInsertionException {
 
@@ -215,8 +212,9 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
-		createGhidraMemoryBlock(is, startingAddr, program, monitor, size, blockName, readPermission,
-				writePermission, executePermission);
-		createData(program, startingAddr, dataType);
+		createGhidraMemoryBlock(is, startingAddr, program, monitor,
+				NsisCommonHeader.getHeaderSize(), blockName, readPermission, writePermission,
+				executePermission);
+		createData(program, startingAddr, NsisCommonHeader.STRUCTURE);
 	}
 }

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -182,19 +182,6 @@ public class NsisExecutable {
 		return this.firstHeader.flags;
 	}
 
-	/**
-	 * Returns the data structure of the Nsis Script Header.
-	 * 
-	 * @return a DataType object that represents the Nsis Script header
-	 */
-	public DataType getHeaderDataType() {
-		return this.firstHeader.toDataType();
-	}
-
-	public DataType getCommonHeaderDataType() {
-		return this.commonHeader.toDataType();
-	}
-
 	public int getCommonHeaderFlags() {
 		return this.commonHeader.getFlags();
 	}

--- a/nsis/src/nsis/format/NsisCommonHeader.java
+++ b/nsis/src/nsis/format/NsisCommonHeader.java
@@ -43,7 +43,7 @@ public class NsisCommonHeader implements StructConverter {
 	private int strUninstCmd;
 	private int strWininit;
 
-	private final static Structure STRUCTURE;
+	public final static Structure STRUCTURE;
 
 	static {
 		// Values are named after the NSIS implementation of header struct:

--- a/nsis/src/nsis/format/NsisFirstHeader.java
+++ b/nsis/src/nsis/format/NsisFirstHeader.java
@@ -17,7 +17,7 @@ public class NsisFirstHeader implements StructConverter {
 	public final int inflatedHeaderSize;
 	public final int archiveSize;
 	public final int compressedHeaderSize;
-	private final static Structure STRUCTURE;
+	public final static Structure STRUCTURE;
 
 	static {
 		// Values are named after the NSIS implementation of the first header:


### PR DESCRIPTION
Fixes #38 

Added createGhidraMemoryBlock function and changes STRUCTURE objects to public.

I am wondering if creating a `GhidraConstants.java` class would be a good idea or if it would be 
superfluous. I could declare all the different section names there and their r/w/x permissions. Let me know if you have any thoughts about that. 

Also, keeping the init function for each section is a good idea because in some cases I will need to call `createGhidraMemoryBlock()` or `createData()` multiple times for one section. (for example #37 pull request)

- [ x] Tests pass
