### PR TITLE
Nsis analyzer (auto decompile entries)

### DIFF
--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -34,7 +34,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 
 		// TODO: Name the analyzer and give it a description.
 
-		super("Decompile into NSIS script", "Decompiles the entries section into NSIS script",
+		super("Nsis", "Analyzer description goes here",
 				AnalyzerType.BYTE_ANALYZER);
 	}
 
@@ -54,7 +54,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 		// Return true
 		// if it can.
 
-		return true;
+		return false;
 	}
 
 	@Override

--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -74,7 +74,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
 			throws CancelledException {
 		MemoryBlock entriesBlock = program.getMemory()
-				.getBlock(NsisConstants.entriesMemoryBlockName);
+				.getBlock(NsisConstants.ENTRIES_MEMORY_BLOCK_NAME);
 		Disassembler disassembler = Disassembler.getDisassembler(program, monitor, null);
 		AddressSet modifiedAddrSet = disassembler.disassemble(entriesBlock.getStart(), null);
 		if (modifiedAddrSet.isEmpty()) {

--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -19,6 +19,7 @@ import ghidra.app.services.AbstractAnalyzer;
 import ghidra.app.services.AnalyzerType;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.framework.options.Options;
+import ghidra.program.disassemble.Disassembler;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.listing.Program;
 import ghidra.util.exception.CancelledException;
@@ -75,6 +76,10 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 		// the
 		// analysis succeeded.
 
-		return false;
+		Disassembler disassembler = Disassembler.getDisassembler(program, monitor, null);
+		disassembler.disassemble(program.getImageBase(), null);
+		
+		
+		return true;
 	}
 }

--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -34,7 +34,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 
 		// TODO: Name the analyzer and give it a description.
 
-		super("Nsis", "Analyzer description goes here",
+		super("Decompile into NSIS script", "Decompiles the entries section into NSIS script",
 				AnalyzerType.BYTE_ANALYZER);
 	}
 
@@ -54,7 +54,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 		// Return true
 		// if it can.
 
-		return false;
+		return true;
 	}
 
 	@Override

--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -20,8 +20,10 @@ import ghidra.app.services.AnalyzerType;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.framework.options.Options;
 import ghidra.program.disassemble.Disassembler;
+import ghidra.program.model.address.AddressSet;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 
@@ -70,16 +72,13 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 	@Override
 	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
 			throws CancelledException {
-
-		// TODO: Perform analysis when things get added to the 'program'. Return
-		// true if
-		// the
-		// analysis succeeded.
-
+		MemoryBlock entriesBlock = program.getMemory().getBlock(".entries");
 		Disassembler disassembler = Disassembler.getDisassembler(program, monitor, null);
-		disassembler.disassemble(program.getImageBase(), null);
-		
-		
+
+		AddressSet modifiedAddrSet = disassembler.disassemble(entriesBlock.getStart(), null);
+		if (modifiedAddrSet.isEmpty()) {
+			return false;
+		}
 		return true;
 	}
 }

--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -26,6 +26,7 @@ import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
+import nsis.file.NsisConstants;
 
 /**
  * This analyzer finds NSIS bytecode and will try to decompile it into the
@@ -72,9 +73,9 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 	@Override
 	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
 			throws CancelledException {
-		MemoryBlock entriesBlock = program.getMemory().getBlock(".entries");
+		MemoryBlock entriesBlock = program.getMemory()
+				.getBlock(NsisConstants.entriesMemoryBlockName);
 		Disassembler disassembler = Disassembler.getDisassembler(program, monitor, null);
-
 		AddressSet modifiedAddrSet = disassembler.disassemble(entriesBlock.getStart(), null);
 		if (modifiedAddrSet.isEmpty()) {
 			return false;

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -204,7 +204,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor, NsisFirstHeader.getHeaderSize(),
-				NsisConstants.firstHeaderMemoryBlockName, readPermission, writePermission,
+				NsisConstants.FIRST_HEADER_MEMORY_BLOCK_NAME, readPermission, writePermission,
 				executePermission);
 		createData(program, startingAddr, NsisFirstHeader.STRUCTURE);
 	}
@@ -236,7 +236,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisCommonHeader.getHeaderSize(), NsisConstants.commonHeaderMemoryBlockName,
+				NsisCommonHeader.getHeaderSize(), NsisConstants.COMMON_HEADER_MEMORY_BLOCK_NAME,
 				readPermission, writePermission, executePermission);
 		createData(program, startingAddr, NsisCommonHeader.STRUCTURE);
 	}
@@ -270,7 +270,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisPage.getPageSize() * numPages, NsisConstants.pagesMemoryBlockName,
+				NsisPage.getPageSize() * numPages, NsisConstants.PAGES_MEMORY_BLOCK_NAME,
 				readPermission, writePermission, executePermission);
 
 		for (int i = 0; i < numPages; i++) {
@@ -305,7 +305,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisSection.getSectionSize() * nbSections, NsisConstants.sectionsMemoryBlockName,
+				NsisSection.getSectionSize() * nbSections, NsisConstants.SECTIONS_MEMORY_BLOCK_NAME,
 				readPermission, writePermission, executePermission);
 
 		for (int i = 0; i < nbSections; i++) {
@@ -341,7 +341,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		boolean executePermission = true;
 
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisEntry.getEntrySize() * nbEntries, NsisConstants.entriesMemoryBlockName,
+				NsisEntry.getEntrySize() * nbEntries, NsisConstants.ENTRIES_MEMORY_BLOCK_NAME,
 				readPermission, writePermission, executePermission);
 	}
 

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -71,7 +71,6 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		try {
 			NsisExecutable ne = NsisExecutable
 					.createNsisExecutable(RethrowContinuesFactory.INSTANCE, provider);
-			
 			LoadSpec my_spec = new LoadSpec(this, 0x400000,
 					new LanguageCompilerSpecPair("Nsis:LE:32:default", "default"), true);
 			loadSpecs.add(my_spec);

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -72,7 +72,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			NsisExecutable ne = NsisExecutable
 					.createNsisExecutable(RethrowContinuesFactory.INSTANCE, provider);
 			
-			LoadSpec my_spec = new LoadSpec(this, 0x00400000,
+			LoadSpec my_spec = new LoadSpec(this, 0x400000,
 					new LanguageCompilerSpecPair("Nsis:LE:32:default", "default"), true);
 			loadSpecs.add(my_spec);
 		} catch (InvalidFormatException e) {

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -48,6 +48,7 @@ import ghidra.util.InvalidNameException;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.DuplicateNameException;
 import ghidra.util.task.TaskMonitor;
+import nsis.file.NsisConstants;
 import nsis.file.NsisExecutable;
 import nsis.format.InvalidFormatException;
 import nsis.format.NsisCommonHeader;
@@ -71,7 +72,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		try {
 			NsisExecutable ne = NsisExecutable
 					.createNsisExecutable(RethrowContinuesFactory.INSTANCE, provider);
-			LoadSpec my_spec = new LoadSpec(this, 0x400000,
+			LoadSpec my_spec = new LoadSpec(this, ne.getHeaderOffset(),
 					new LanguageCompilerSpecPair("Nsis:LE:32:default", "default"), true);
 			loadSpecs.add(my_spec);
 		} catch (InvalidFormatException e) {
@@ -199,12 +200,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			TaskMonitor monitor) throws MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException, LockException, CodeUnitInsertionException {
 
-		String blockName = ".first_header";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor, NsisFirstHeader.getHeaderSize(),
-				blockName, readPermission, writePermission, executePermission);
+				NsisConstants.firstHeaderMemoryBlockName, readPermission, writePermission,
+				executePermission);
 		createData(program, startingAddr, NsisFirstHeader.STRUCTURE);
 	}
 
@@ -231,13 +232,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			throws LockException, MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException, CodeUnitInsertionException {
 
-		String blockName = ".common_header";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisCommonHeader.getHeaderSize(), blockName, readPermission, writePermission,
-				executePermission);
+				NsisCommonHeader.getHeaderSize(), NsisConstants.commonHeaderMemoryBlockName,
+				readPermission, writePermission, executePermission);
 		createData(program, startingAddr, NsisCommonHeader.STRUCTURE);
 	}
 
@@ -266,13 +266,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			DuplicateNameException, MemoryConflictException, AddressOverflowException,
 			CancelledException, CodeUnitInsertionException, InvalidNameException {
 
-		String blockName = ".pages";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisPage.getPageSize() * numPages, blockName, readPermission, writePermission,
-				executePermission);
+				NsisPage.getPageSize() * numPages, NsisConstants.pagesMemoryBlockName,
+				readPermission, writePermission, executePermission);
 
 		for (int i = 0; i < numPages; i++) {
 			NsisPage.STRUCTURE.setName("Page #" + (i + 1));
@@ -302,13 +301,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			AddressOverflowException, CancelledException, DuplicateNameException,
 			CodeUnitInsertionException, InvalidNameException {
 
-		String blockName = ".section_headers";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisSection.getSectionSize() * nbSections, blockName, readPermission,
-				writePermission, executePermission);
+				NsisSection.getSectionSize() * nbSections, NsisConstants.sectionsMemoryBlockName,
+				readPermission, writePermission, executePermission);
 
 		for (int i = 0; i < nbSections; i++) {
 			NsisSection.STRUCTURE.setName("Section #" + (i + 1));
@@ -338,14 +336,13 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			throws LockException, MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException, CodeUnitInsertionException {
 
-		String blockName = ".entries";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = true;
 
 		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisEntry.getEntrySize() * nbEntries, blockName, readPermission, writePermission,
-				executePermission);
+				NsisEntry.getEntrySize() * nbEntries, NsisConstants.entriesMemoryBlockName,
+				readPermission, writePermission, executePermission);
 	}
 
 }

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -71,7 +71,8 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 		try {
 			NsisExecutable ne = NsisExecutable
 					.createNsisExecutable(RethrowContinuesFactory.INSTANCE, provider);
-			LoadSpec my_spec = new LoadSpec(this, 0x400000,
+			
+			LoadSpec my_spec = new LoadSpec(this, 0x00400000,
 					new LanguageCompilerSpecPair("Nsis:LE:32:default", "default"), true);
 			loadSpecs.add(my_spec);
 		} catch (InvalidFormatException e) {

--- a/nsis/src/nsis/file/NsisConstants.java
+++ b/nsis/src/nsis/file/NsisConstants.java
@@ -19,9 +19,9 @@ public class NsisConstants {
 	}
 
 	// Ghidra memory block names
-	public static final String firstHeaderMemoryBlockName = ".first_header";
-	public static final String commonHeaderMemoryBlockName = ".common_header";
-	public static final String pagesMemoryBlockName = ".pages";
-	public static final String sectionsMemoryBlockName = ".section_headers";
-	public static final String entriesMemoryBlockName = ".entries";
+	public static final String FIRST_HEADER_MEMORY_BLOCK_NAME = ".first_header";
+	public static final String COMMON_HEADER_MEMORY_BLOCK_NAME = ".common_header";
+	public static final String PAGES_MEMORY_BLOCK_NAME = ".pages";
+	public static final String SECTIONS_MEMORY_BLOCK_NAME = ".section_headers";
+	public static final String ENTRIES_MEMORY_BLOCK_NAME = ".entries";
 }

--- a/nsis/src/nsis/file/NsisConstants.java
+++ b/nsis/src/nsis/file/NsisConstants.java
@@ -17,4 +17,11 @@ public class NsisConstants {
 	public enum BlockHeaderType {
 		PAGES, SECTIONS, ENTRIES, STRINGS, LANGTABLES, CONTROL_COLORS, BACKGROUND_FONT, DATA
 	}
+
+	// Ghidra memory block names
+	public static final String firstHeaderMemoryBlockName = ".first_header";
+	public static final String commonHeaderMemoryBlockName = ".common_header";
+	public static final String pagesMemoryBlockName = ".pages";
+	public static final String sectionsMemoryBlockName = ".section_headers";
+	public static final String entriesMemoryBlockName = ".entries";
 }


### PR DESCRIPTION
Added a Nsis analyzer that will automatically decompile the bytecode in the .entries memory block. Also converted the memory block names into constants and updated the image base in the Nsis loader.

- [x ] Tests pass

