### PR TITLE
Zero length blocks

### DIFF
--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -34,7 +34,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 
 		// TODO: Name the analyzer and give it a description.
 
-		super("Decompile into NSIS script", "Decompiles the entries section into NSIS script",
+		super("Nsis", "Analyzer description goes here",
 				AnalyzerType.BYTE_ANALYZER);
 	}
 
@@ -54,7 +54,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 		// Return true
 		// if it can.
 
-		return true;
+		return false;
 	}
 
 	@Override

--- a/nsis/src/nsis/NsisAnalyzer.java
+++ b/nsis/src/nsis/NsisAnalyzer.java
@@ -34,7 +34,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 
 		// TODO: Name the analyzer and give it a description.
 
-		super("Nsis", "Analyzer description goes here",
+		super("Decompile into NSIS script", "Decompiles the entries section into NSIS script",
 				AnalyzerType.BYTE_ANALYZER);
 	}
 
@@ -54,7 +54,7 @@ public class NsisAnalyzer extends AbstractAnalyzer {
 		// Return true
 		// if it can.
 
-		return false;
+		return true;
 	}
 
 	@Override

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -106,31 +106,24 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 
 				Address pagesSectionAddress = commonHeaderAddress
 						.add(NsisCommonHeader.getHeaderSize());
-				if (ne.getNumPages() > 0) {
-					initPagesSection(bodyInputStream, pagesSectionAddress, program, monitor,
-							ne.getNumPages());
-				}
+				initPagesSection(bodyInputStream, pagesSectionAddress, program, monitor,
+						ne.getNumPages());
 
 				Address sectionHeadersAddress = pagesSectionAddress
 						.add(NsisPage.getPageSize() * ne.getNumPages());
-				if (ne.getNumSections() > 0) {
-					initSectionHeaders(bodyInputStream, sectionHeadersAddress, program, monitor,
-							ne.getNumSections());
-				}
+				initSectionHeaders(bodyInputStream, sectionHeadersAddress, program, monitor,
+						ne.getNumSections());
 
 				Address entriesSectionAddress = sectionHeadersAddress
 						.add(NsisSection.getSectionSize() * ne.getNumSections());
-				if (ne.getNumEntries() > 0) {
-					initEntriesSection(bodyInputStream, entriesSectionAddress, program, monitor,
-							ne.getNumEntries());
-				}
+				initEntriesSection(bodyInputStream, entriesSectionAddress, program, monitor,
+						ne.getNumEntries());
 
 				Address stringsAddress = entriesSectionAddress
 						.add(NsisEntry.getEntrySize() * ne.getNumEntries());
-				if (ne.getStringsSectionSize() > 0) {
-					initStringsSection(bodyInputStream, stringsAddress, program, monitor,
-							ne.getStringsSectionSize());
-				}
+				initStringsSection(bodyInputStream, stringsAddress, program, monitor,
+						ne.getStringsSectionSize());
+
 			}
 
 		} catch (Exception e) {
@@ -278,18 +271,19 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			TaskMonitor monitor, int numPages) throws IOException, LockException,
 			DuplicateNameException, MemoryConflictException, AddressOverflowException,
 			CancelledException, CodeUnitInsertionException, InvalidNameException {
+		if (numPages > 0) {
+			boolean readPermission = true;
+			boolean writePermission = false;
+			boolean executePermission = false;
+			createGhidraMemoryBlock(is, startingAddr, program, monitor,
+					NsisPage.getPageSize() * numPages, NsisConstants.PAGES_MEMORY_BLOCK_NAME,
+					readPermission, writePermission, executePermission);
 
-		boolean readPermission = true;
-		boolean writePermission = false;
-		boolean executePermission = false;
-		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisPage.getPageSize() * numPages, NsisConstants.PAGES_MEMORY_BLOCK_NAME,
-				readPermission, writePermission, executePermission);
-
-		for (int i = 0; i < numPages; i++) {
-			NsisPage.STRUCTURE.setName("Page #" + (i + 1));
-			createData(program, startingAddr, NsisPage.STRUCTURE);
-			startingAddr = startingAddr.add(NsisPage.getPageSize());
+			for (int i = 0; i < numPages; i++) {
+				NsisPage.STRUCTURE.setName("Page #" + (i + 1));
+				createData(program, startingAddr, NsisPage.STRUCTURE);
+				startingAddr = startingAddr.add(NsisPage.getPageSize());
+			}
 		}
 	}
 
@@ -310,21 +304,24 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	 * @throws InvalidNameException
 	 */
 	private void initSectionHeaders(InputStream is, Address startingAddr, Program program,
-			TaskMonitor monitor, int nbSections) throws LockException, MemoryConflictException,
+			TaskMonitor monitor, int numSections) throws LockException, MemoryConflictException,
 			AddressOverflowException, CancelledException, DuplicateNameException,
 			CodeUnitInsertionException, InvalidNameException {
 
-		boolean readPermission = true;
-		boolean writePermission = false;
-		boolean executePermission = false;
-		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisSection.getSectionSize() * nbSections, NsisConstants.SECTIONS_MEMORY_BLOCK_NAME,
-				readPermission, writePermission, executePermission);
+		if (numSections > 0) {
+			boolean readPermission = true;
+			boolean writePermission = false;
+			boolean executePermission = false;
+			createGhidraMemoryBlock(is, startingAddr, program, monitor,
+					NsisSection.getSectionSize() * numSections,
+					NsisConstants.SECTIONS_MEMORY_BLOCK_NAME, readPermission, writePermission,
+					executePermission);
 
-		for (int i = 0; i < nbSections; i++) {
-			NsisSection.STRUCTURE.setName("Section #" + (i + 1));
-			createData(program, startingAddr, NsisSection.STRUCTURE);
-			startingAddr = startingAddr.add(NsisSection.getSectionSize());
+			for (int i = 0; i < numSections; i++) {
+				NsisSection.STRUCTURE.setName("Section #" + (i + 1));
+				createData(program, startingAddr, NsisSection.STRUCTURE);
+				startingAddr = startingAddr.add(NsisSection.getSectionSize());
+			}
 		}
 	}
 
@@ -346,17 +343,19 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 	 * @throws CodeUnitInsertionException
 	 */
 	private void initEntriesSection(InputStream is, Address startingAddr, Program program,
-			TaskMonitor monitor, int nbEntries)
+			TaskMonitor monitor, int numEntries)
 			throws LockException, MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException, CodeUnitInsertionException {
 
-		boolean readPermission = true;
-		boolean writePermission = false;
-		boolean executePermission = true;
+		if (numEntries > 0) {
+			boolean readPermission = true;
+			boolean writePermission = false;
+			boolean executePermission = true;
 
-		createGhidraMemoryBlock(is, startingAddr, program, monitor,
-				NsisEntry.getEntrySize() * nbEntries, NsisConstants.ENTRIES_MEMORY_BLOCK_NAME,
-				readPermission, writePermission, executePermission);
+			createGhidraMemoryBlock(is, startingAddr, program, monitor,
+					NsisEntry.getEntrySize() * numEntries, NsisConstants.ENTRIES_MEMORY_BLOCK_NAME,
+					readPermission, writePermission, executePermission);
+		}
 	}
 
 	/**
@@ -379,12 +378,14 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
 			AddressOverflowException, CancelledException, DuplicateNameException {
 
-		boolean readPermission = true;
-		boolean writePermission = false;
-		boolean executePermission = false;
-		createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength,
-				NsisConstants.STRINGS_MEMORY_BLOCK_NAME, readPermission, writePermission,
-				executePermission);
+		if (sectionLength > 0) {
+			boolean readPermission = true;
+			boolean writePermission = false;
+			boolean executePermission = false;
+			createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength,
+					NsisConstants.STRINGS_MEMORY_BLOCK_NAME, readPermission, writePermission,
+					executePermission);
+		}
 	}
 
 }

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -271,6 +271,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			TaskMonitor monitor, int numPages) throws IOException, LockException,
 			DuplicateNameException, MemoryConflictException, AddressOverflowException,
 			CancelledException, CodeUnitInsertionException, InvalidNameException {
+
 		if (numPages > 0) {
 			boolean readPermission = true;
 			boolean writePermission = false;

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -176,12 +176,14 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			boolean writePermission, boolean executePermission)
 			throws LockException, MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException {
-		Memory memory = program.getMemory();
-		MemoryBlock firstHeaderBlock = memory.createInitializedBlock(blockName, startingAddr, is,
-				size, monitor, /* Overlay */ false);
-		firstHeaderBlock.setRead(readPermission);
-		firstHeaderBlock.setWrite(writePermission);
-		firstHeaderBlock.setExecute(executePermission);
+		if (size > 0) {
+			Memory memory = program.getMemory();
+			MemoryBlock firstHeaderBlock = memory.createInitializedBlock(blockName, startingAddr,
+					is, size, monitor, /* Overlay */ false);
+			firstHeaderBlock.setRead(readPermission);
+			firstHeaderBlock.setWrite(writePermission);
+			firstHeaderBlock.setExecute(executePermission);
+		}
 	}
 
 	/**

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -106,23 +106,31 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 
 				Address pagesSectionAddress = commonHeaderAddress
 						.add(NsisCommonHeader.getHeaderSize());
-				initPagesSection(bodyInputStream, pagesSectionAddress, program, monitor,
-						ne.getNumPages());
+				if (ne.getNumPages() > 0) {
+					initPagesSection(bodyInputStream, pagesSectionAddress, program, monitor,
+							ne.getNumPages());
+				}
 
 				Address sectionHeadersAddress = pagesSectionAddress
 						.add(NsisPage.getPageSize() * ne.getNumPages());
-				initSectionHeaders(bodyInputStream, sectionHeadersAddress, program, monitor,
-						ne.getNumSections());
+				if (ne.getNumSections() > 0) {
+					initSectionHeaders(bodyInputStream, sectionHeadersAddress, program, monitor,
+							ne.getNumSections());
+				}
 
 				Address entriesSectionAddress = sectionHeadersAddress
 						.add(NsisSection.getSectionSize() * ne.getNumSections());
-				initEntriesSection(bodyInputStream, entriesSectionAddress, program, monitor,
-						ne.getNumEntries());
+				if (ne.getNumEntries() > 0) {
+					initEntriesSection(bodyInputStream, entriesSectionAddress, program, monitor,
+							ne.getNumEntries());
+				}
 
 				Address stringsAddress = entriesSectionAddress
 						.add(NsisEntry.getEntrySize() * ne.getNumEntries());
-				initStringsSection(bodyInputStream, stringsAddress, program, monitor,
-						ne.getStringsSectionSize());
+				if (ne.getStringsSectionSize() > 0) {
+					initStringsSection(bodyInputStream, stringsAddress, program, monitor,
+							ne.getStringsSectionSize());
+				}
 			}
 
 		} catch (Exception e) {
@@ -176,14 +184,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			boolean writePermission, boolean executePermission)
 			throws LockException, MemoryConflictException, AddressOverflowException,
 			CancelledException, DuplicateNameException {
-		if (size > 0) {
-			Memory memory = program.getMemory();
-			MemoryBlock firstHeaderBlock = memory.createInitializedBlock(blockName, startingAddr,
-					is, size, monitor, /* Overlay */ false);
-			firstHeaderBlock.setRead(readPermission);
-			firstHeaderBlock.setWrite(writePermission);
-			firstHeaderBlock.setExecute(executePermission);
-		}
+		Memory memory = program.getMemory();
+		MemoryBlock firstHeaderBlock = memory.createInitializedBlock(blockName, startingAddr, is,
+				size, monitor, /* Overlay */ false);
+		firstHeaderBlock.setRead(readPermission);
+		firstHeaderBlock.setWrite(writePermission);
+		firstHeaderBlock.setExecute(executePermission);
 	}
 
 	/**
@@ -373,12 +379,12 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
 			TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
 			AddressOverflowException, CancelledException, DuplicateNameException {
 
-		String blockName = ".strings";
 		boolean readPermission = true;
 		boolean writePermission = false;
 		boolean executePermission = false;
-		createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength, blockName,
-				readPermission, writePermission, executePermission);
+		createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength,
+				NsisConstants.STRINGS_MEMORY_BLOCK_NAME, readPermission, writePermission,
+				executePermission);
 	}
 
 }

--- a/nsis/src/nsis/file/NsisConstants.java
+++ b/nsis/src/nsis/file/NsisConstants.java
@@ -24,4 +24,5 @@ public class NsisConstants {
 	public static final String PAGES_MEMORY_BLOCK_NAME = ".pages";
 	public static final String SECTIONS_MEMORY_BLOCK_NAME = ".section_headers";
 	public static final String ENTRIES_MEMORY_BLOCK_NAME = ".entries";
+	public static final String STRINGS_MEMORY_BLOCK_NAME = ".strings";
 }


### PR DESCRIPTION
Prevent from initializing a memory block that has a length of 0. We don't want to throw an error, because it is possible that some binaries don't have a pages section for example (then, the length will be 0).

- [x ] Tests pass

