### PR TITLE
Added langtables section

### DIFF
--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -115,6 +115,10 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
         initStringsSection(bodyInputStream, stringsAddress, program, monitor,
             ne.getStringsSectionSize());
 
+        Address langTablesAddress = commonHeaderAddress.add(ne.getLangTablesOffset());
+        initLangTablesSection(bodyInputStream, langTablesAddress, program, monitor,
+            ne.getLangTablesSectionSize());
+
       }
 
     } catch (Exception e) {
@@ -367,6 +371,34 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
       boolean executePermission = false;
       createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength,
           NsisConstants.STRINGS_MEMORY_BLOCK_NAME, readPermission, writePermission,
+          executePermission);
+    }
+  }
+
+  /**
+   * Initializes the langTables section and adds the it to the "program Trees" view in Ghidra.
+   * 
+   * @param is
+   * @param startingAddr
+   * @param program
+   * @param monitor
+   * @param sectionLength
+   * @throws LockException
+   * @throws MemoryConflictException
+   * @throws AddressOverflowException
+   * @throws CancelledException
+   * @throws DuplicateNameException
+   */
+  private void initLangTablesSection(InputStream is, Address startingAddr, Program program,
+      TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
+      AddressOverflowException, CancelledException, DuplicateNameException {
+
+    if (sectionLength > 0) {
+      boolean readPermission = true;
+      boolean writePermission = false;
+      boolean executePermission = false;
+      createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength,
+          NsisConstants.LANGTABLES_MEMORY_BLOCK_NAME, readPermission, writePermission,
           executePermission);
     }
   }

--- a/nsis/src/nsis/file/NsisConstants.java
+++ b/nsis/src/nsis/file/NsisConstants.java
@@ -24,6 +24,7 @@ public class NsisConstants {
   public static final String SECTIONS_MEMORY_BLOCK_NAME = ".section_headers";
   public static final String ENTRIES_MEMORY_BLOCK_NAME = ".entries";
   public static final String STRINGS_MEMORY_BLOCK_NAME = ".strings";
+  public static final String LANGTABLES_MEMORY_BLOCK_NAME = ".langtables";
 
   // NSIS instruction constants
   public static final int INSTRUCTION_BYTE_LENGTH = 0x1c;

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -22,6 +22,7 @@ import nsis.format.NsisBlockHeader;
 import nsis.format.NsisCommonHeader;
 import nsis.format.NsisEntry;
 import nsis.format.NsisFirstHeader;
+import nsis.format.NsisLangTables;
 import nsis.format.NsisPage;
 import nsis.format.NsisSection;
 import nsis.format.NsisStrings;
@@ -45,6 +46,7 @@ public class NsisExecutable {
   private NsisSection[] sections;
   private NsisEntry[] entries;
   private NsisStrings strings;
+  private NsisLangTables langTables;
 
   /**
    * Use createNsisExecutable to create a Nsis Executable object
@@ -107,6 +109,9 @@ public class NsisExecutable {
       this.strings = new NsisStrings(blockReader,
           this.getBlockHeader(NsisConstants.BlockHeaderType.STRINGS.ordinal()).getOffset(),
           this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset());
+      this.langTables = new NsisLangTables(blockReader,
+          this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset(),
+          this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset());
     }
   }
 
@@ -313,6 +318,16 @@ public class NsisExecutable {
   }
 
   /**
+   * Get the offset of the langTables section.
+   * 
+   * @return
+   */
+  public int getLangTablesOffset() {
+    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal())
+        .getOffset();
+  }
+
+  /**
    * Get the number of pages in the Nsis executable
    * 
    * @return the number of pages
@@ -377,5 +392,14 @@ public class NsisExecutable {
    */
   public int getStringsSectionSize() {
     return this.strings.getStringsSectionLength();
+  }
+
+  /**
+   * Get the size of the langTables section of the NSIS executable
+   * 
+   * @return
+   */
+  public int getLangTablesSectionSize() {
+    return this.langTables.getLangTablesSectionLength();
   }
 }

--- a/nsis/src/nsis/format/NsisLangTables.java
+++ b/nsis/src/nsis/format/NsisLangTables.java
@@ -1,0 +1,24 @@
+package nsis.format;
+
+import ghidra.app.util.bin.BinaryReader;
+
+public class NsisLangTables {
+  private int sectionLength;
+
+  /**
+   * When creating a NsisLangTables object, the pointer of the reader is advanced to the end of the
+   * langTables section.
+   * 
+   * @param reader
+   * @param sectionStartOffset
+   * @param sectionEndOffset
+   */
+  public NsisLangTables(BinaryReader reader, int sectionStartOffset, int sectionEndOffset) {
+    this.sectionLength = sectionEndOffset - sectionStartOffset;
+    reader.setPointerIndex(reader.getPointerIndex() + this.sectionLength);
+  }
+
+  public int getLangTablesSectionLength() {
+    return this.sectionLength;
+  }
+}

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -73,6 +73,9 @@ public class NsisExecutableTest {
 
       // Strings
       assertEquals(0x11c, ne.getStringsSectionSize());
+
+      // LangTables
+      assertEquals(0xc2, ne.getLangTablesSectionSize());
     }
   }
 
@@ -125,6 +128,9 @@ public class NsisExecutableTest {
 
       // Strings
       assertEquals(0x11c, ne.getStringsSectionSize());
+
+      // LangTables
+      assertEquals(0xc2, ne.getLangTablesSectionSize());
     }
   }
 
@@ -178,6 +184,9 @@ public class NsisExecutableTest {
 
       // Strings
       assertEquals(0x11c, ne.getStringsSectionSize());
+
+      // LangTables
+      assertEquals(0xc2, ne.getLangTablesSectionSize());
     }
   }
 
@@ -231,6 +240,9 @@ public class NsisExecutableTest {
 
       // Strings
       assertEquals(0x11c, ne.getStringsSectionSize());
+
+      // LangTables
+      assertEquals(0xc2, ne.getLangTablesSectionSize());
     }
   }
 


### PR DESCRIPTION
Adds the 'langTables' section, which is after the strings section. Does not parse the section (it contains raw bytes for now).

- [x ] Tests pass
