### PR TITLE
Fix section lengths

### DIFF
--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -100,22 +100,27 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
         Address commonHeaderAddress = firstHeaderAddress.add(NsisFirstHeader.getHeaderSize());
         initCommonHeader(bodyInputStream, commonHeaderAddress, program, monitor);
 
-        Address pagesSectionAddress = commonHeaderAddress.add(ne.getPagesOffset());
+        Address pagesSectionAddress =
+            commonHeaderAddress.add(ne.getSectionOffset(NsisConstants.BlockHeaderType.PAGES));
         initPagesSection(bodyInputStream, pagesSectionAddress, program, monitor, ne.getNumPages());
 
-        Address sectionHeadersAddress = commonHeaderAddress.add(ne.getSectionsOffset());
+        Address sectionHeadersAddress =
+            commonHeaderAddress.add(ne.getSectionOffset(NsisConstants.BlockHeaderType.SECTIONS));
         initSectionHeaders(bodyInputStream, sectionHeadersAddress, program, monitor,
             ne.getNumSections());
 
-        Address entriesSectionAddress = commonHeaderAddress.add(ne.getEntriesOffset());
+        Address entriesSectionAddress =
+            commonHeaderAddress.add(ne.getSectionOffset(NsisConstants.BlockHeaderType.ENTRIES));
         initEntriesSection(bodyInputStream, entriesSectionAddress, program, monitor,
             ne.getNumEntries());
 
-        Address stringsAddress = commonHeaderAddress.add(ne.getStringsOffset());
+        Address stringsAddress =
+            commonHeaderAddress.add(ne.getSectionOffset(NsisConstants.BlockHeaderType.STRINGS));
         initStringsSection(bodyInputStream, stringsAddress, program, monitor,
             ne.getStringsSectionSize());
 
-        Address langTablesAddress = commonHeaderAddress.add(ne.getLangTablesOffset());
+        Address langTablesAddress =
+            commonHeaderAddress.add(ne.getSectionOffset(NsisConstants.BlockHeaderType.LANGTABLES));
         initLangTablesSection(bodyInputStream, langTablesAddress, program, monitor,
             ne.getLangTablesSectionSize());
 

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -167,7 +167,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
    * @throws LockException
    */
   private void createGhidraMemoryBlock(InputStream is, Address startingAddr, Program program,
-      TaskMonitor monitor, int size, String blockName, boolean readPermission,
+      TaskMonitor monitor, long size, String blockName, boolean readPermission,
       boolean writePermission, boolean executePermission)
       throws LockException, MemoryConflictException, AddressOverflowException, CancelledException,
       DuplicateNameException {
@@ -362,7 +362,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
    * @throws DuplicateNameException
    */
   private void initStringsSection(InputStream is, Address startingAddr, Program program,
-      TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
+      TaskMonitor monitor, long sectionLength) throws LockException, MemoryConflictException,
       AddressOverflowException, CancelledException, DuplicateNameException {
 
     if (sectionLength > 0) {
@@ -390,7 +390,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
    * @throws DuplicateNameException
    */
   private void initLangTablesSection(InputStream is, Address startingAddr, Program program,
-      TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
+      TaskMonitor monitor, long sectionLength) throws LockException, MemoryConflictException,
       AddressOverflowException, CancelledException, DuplicateNameException {
 
     if (sectionLength > 0) {

--- a/nsis/src/nsis/file/NsisConstants.java
+++ b/nsis/src/nsis/file/NsisConstants.java
@@ -7,15 +7,18 @@ public class NsisConstants {
       {'N', 'u', 'l', 'l', 's', 'o', 'f', 't', 'I', 'n', 's', 't'};
   public static final int NSIS_MAX_STRLEN = 1024;
   public static final int NSIS_MAX_INST_TYPES = 32;
-  public static final byte COMPRESSION_LZMA = 0x5d;
-  public static final byte COMPRESSION_BZIP2 = 0x31;
-  public static final int COMPRESSION_LZMA_HEADER_LENGTH = 5;
-
+  public static final int NSIS_CRC_LENGTH = 4;
+  
   // The order of the blocks is important as their ordinal value corresponds to
   // their position in the NsisCommonHeader
   public enum BlockHeaderType {
     PAGES, SECTIONS, ENTRIES, STRINGS, LANGTABLES, CONTROL_COLORS, BACKGROUND_FONT, DATA
   }
+  
+  // Compression related constants
+  public static final byte COMPRESSION_LZMA = 0x5d;
+  public static final byte COMPRESSION_BZIP2 = 0x31;
+  public static final int COMPRESSION_LZMA_HEADER_LENGTH = 5;
 
   // Ghidra memory block names
   public static final String FIRST_HEADER_MEMORY_BLOCK_NAME = ".first_header";

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -47,6 +47,7 @@ public class NsisExecutable {
   private NsisEntry[] entries;
   private NsisStrings strings;
   private NsisLangTables langTables;
+  private long crcSignatureOffset;
 
   /**
    * Use createNsisExecutable to create a Nsis Executable object
@@ -92,6 +93,8 @@ public class NsisExecutable {
   private void initNsisExecutable(GenericFactory factory)
       throws IOException, InvalidFormatException {
     initFirstHeader();
+    this.crcSignatureOffset =
+        this.headerOffset + (this.firstHeader.archiveSize - NsisConstants.NSIS_CRC_LENGTH);
     this.decompressionProvider = getDecompressionProvider();
     try (InputStream decompressesdStream = this.getDecompressedInputStream()) {
       ByteProvider blockDataByteProvider =

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -102,11 +102,11 @@ public class NsisExecutable {
       BinaryReader blockReader = new FactoryBundledWithBinaryReader(factory, blockDataByteProvider,
           NsisConstants.IS_LITTLE_ENDIAN);
       this.commonHeader = new NsisCommonHeader(blockReader);
-      blockReader.setPointerIndex(this.getPagesOffset());
+      blockReader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.PAGES));
       this.pages = getPages(blockReader);
-      blockReader.setPointerIndex(this.getSectionsOffset());
+      blockReader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.SECTIONS));
       this.sections = getSections(blockReader);
-      blockReader.setPointerIndex(this.getEntriesOffset());
+      blockReader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.ENTRIES));
       this.entries = getEntries(blockReader);
       initStrings(blockReader);
       initLangTables(blockReader);
@@ -180,7 +180,7 @@ public class NsisExecutable {
    * @param reader
    */
   private void initStrings(BinaryReader reader) {
-    reader.setPointerIndex(this.getStringsOffset());
+    reader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.STRINGS));
     long stringsSectionLength = getSectionSizeFromOffsets(
         this.getBlockHeader(NsisConstants.BlockHeaderType.STRINGS.ordinal()).getOffset(),
         this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset());
@@ -194,7 +194,7 @@ public class NsisExecutable {
    * @param reader
    */
   private void initLangTables(BinaryReader reader) {
-    reader.setPointerIndex(this.getLangTablesOffset());
+    reader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.LANGTABLES));
     long langTablesSectionLength = getSectionSizeFromOffsets(
         this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset(),
         this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset());
@@ -304,53 +304,13 @@ public class NsisExecutable {
   }
 
   /**
-   * Get the offset of the Pages section.
+   * Get the offset of the given section
    * 
+   * @param section
    * @return
    */
-  public int getPagesOffset() {
-    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.PAGES.ordinal())
-        .getOffset();
-  }
-
-  /**
-   * Get the offset of the Section headers section.
-   * 
-   * @return
-   */
-  public int getSectionsOffset() {
-    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.SECTIONS.ordinal())
-        .getOffset();
-  }
-
-  /**
-   * Get the offset of the Entries section.
-   * 
-   * @return
-   */
-  public int getEntriesOffset() {
-    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.ENTRIES.ordinal())
-        .getOffset();
-  }
-
-  /**
-   * Get the offset of the Strings section.
-   * 
-   * @return
-   */
-  public int getStringsOffset() {
-    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.STRINGS.ordinal())
-        .getOffset();
-  }
-
-  /**
-   * Get the offset of the langTables section.
-   * 
-   * @return
-   */
-  public int getLangTablesOffset() {
-    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal())
-        .getOffset();
+  public int getSectionOffset(NsisConstants.BlockHeaderType section) {
+    return this.commonHeader.getBlockHeader(section.ordinal()).getOffset();
   }
 
   /**

--- a/nsis/src/nsis/format/NsisLangTables.java
+++ b/nsis/src/nsis/format/NsisLangTables.java
@@ -3,7 +3,7 @@ package nsis.format;
 import ghidra.app.util.bin.BinaryReader;
 
 public class NsisLangTables {
-  private int sectionLength;
+  private long sectionLength;
 
   /**
    * When creating a NsisLangTables object, the pointer of the reader is advanced to the end of the
@@ -13,12 +13,12 @@ public class NsisLangTables {
    * @param sectionStartOffset
    * @param sectionEndOffset
    */
-  public NsisLangTables(BinaryReader reader, int sectionStartOffset, int sectionEndOffset) {
-    this.sectionLength = sectionEndOffset - sectionStartOffset;
+  public NsisLangTables(BinaryReader reader, long sectionLength) {
+    this.sectionLength = sectionLength;
     reader.setPointerIndex(reader.getPointerIndex() + this.sectionLength);
   }
 
-  public int getLangTablesSectionLength() {
+  public long getLangTablesSectionLength() {
     return this.sectionLength;
   }
 }

--- a/nsis/src/nsis/format/NsisStrings.java
+++ b/nsis/src/nsis/format/NsisStrings.java
@@ -3,7 +3,7 @@ package nsis.format;
 import ghidra.app.util.bin.BinaryReader;
 
 public class NsisStrings {
-  private int sectionLength;
+  private long sectionLength;
 
   /**
    * When creating a NsisStrings object, the pointer of the reader is advanced to the end of the
@@ -13,12 +13,12 @@ public class NsisStrings {
    * @param sectionStartOffset
    * @param sectionEndOffset
    */
-  public NsisStrings(BinaryReader reader, int sectionStartOffset, int sectionEndOffset) {
-    this.sectionLength = sectionEndOffset - sectionStartOffset;
+  public NsisStrings(BinaryReader reader, long sectionLength) {
+    this.sectionLength = sectionLength;
     reader.setPointerIndex(reader.getPointerIndex() + this.sectionLength);
   }
 
-  public int getStringsSectionLength() {
+  public long getStringsSectionLength() {
     return this.sectionLength;
   }
 }


### PR DESCRIPTION
Fixes the initialization of the sections with offsets. It didn't account for the initialization of the last section of the file or for the sections that are not there (where offset == 0):
![image](https://user-images.githubusercontent.com/24403370/90292572-248a1300-de50-11ea-9681-94ae866c2c35.png)

So I added those cases and also refactored related redundant functions.

- [ x] Tests pass
