### PR TITLE
Add ctlcolors section

### DIFF
--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -427,7 +427,7 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
    * @throws DuplicateNameException
    */
   private void initCtlColorsSection(InputStream is, Address startingAddr, Program program,
-      TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
+      TaskMonitor monitor, long sectionLength) throws LockException, MemoryConflictException,
       AddressOverflowException, CancelledException, DuplicateNameException {
 
     if (sectionLength > 0) {

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -124,7 +124,8 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
         initLangTablesSection(bodyInputStream, langTablesAddress, program, monitor,
             ne.getLangTablesSectionSize());
 
-        Address ctlColorsAddress = commonHeaderAddress.add(ne.getControlColorsOffset());
+        Address ctlColorsAddress = commonHeaderAddress
+            .add(ne.getSectionOffset(NsisConstants.BlockHeaderType.CONTROL_COLORS));
         initCtlColorsSection(bodyInputStream, ctlColorsAddress, program, monitor,
             ne.getControlColorsSectionSize());
       }

--- a/nsis/src/nsis/NsisLoader.java
+++ b/nsis/src/nsis/NsisLoader.java
@@ -119,6 +119,9 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
         initLangTablesSection(bodyInputStream, langTablesAddress, program, monitor,
             ne.getLangTablesSectionSize());
 
+        Address ctlColorsAddress = commonHeaderAddress.add(ne.getControlColorsOffset());
+        initCtlColorsSection(bodyInputStream, ctlColorsAddress, program, monitor,
+            ne.getControlColorsSectionSize());
       }
 
     } catch (Exception e) {
@@ -403,4 +406,31 @@ public class NsisLoader extends AbstractLibrarySupportLoader {
     }
   }
 
+  /**
+   * Initializes the ctlColors section and adds the it to the "program Trees" view in Ghidra.
+   * 
+   * @param is
+   * @param startingAddr
+   * @param program
+   * @param monitor
+   * @param sectionLength
+   * @throws LockException
+   * @throws MemoryConflictException
+   * @throws AddressOverflowException
+   * @throws CancelledException
+   * @throws DuplicateNameException
+   */
+  private void initCtlColorsSection(InputStream is, Address startingAddr, Program program,
+      TaskMonitor monitor, int sectionLength) throws LockException, MemoryConflictException,
+      AddressOverflowException, CancelledException, DuplicateNameException {
+
+    if (sectionLength > 0) {
+      boolean readPermission = true;
+      boolean writePermission = false;
+      boolean executePermission = false;
+      createGhidraMemoryBlock(is, startingAddr, program, monitor, sectionLength,
+          NsisConstants.CONTROL_COLORS_MEMORY_BLOCK_NAME, readPermission, writePermission,
+          executePermission);
+    }
+  }
 }

--- a/nsis/src/nsis/file/NsisConstants.java
+++ b/nsis/src/nsis/file/NsisConstants.java
@@ -25,6 +25,7 @@ public class NsisConstants {
   public static final String ENTRIES_MEMORY_BLOCK_NAME = ".entries";
   public static final String STRINGS_MEMORY_BLOCK_NAME = ".strings";
   public static final String LANGTABLES_MEMORY_BLOCK_NAME = ".langtables";
+  public static final String CONTROL_COLORS_MEMORY_BLOCK_NAME = ".ctlcolors";
 
   // NSIS instruction constants
   public static final int INSTRUCTION_BYTE_LENGTH = 0x1c;

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -430,7 +430,7 @@ public class NsisExecutable {
     if (currentSectionOffset == 0) {
       return 0;
     } else if (nextSectionOffset == 0) {
-      return this.firstHeader.inflatedHeaderSize - currentSectionOffset;
+      return this.firstHeader.inflatedHeaderSize - currentSectionOffset; // Last section of the file
     }
     return nextSectionOffset - currentSectionOffset;
   }

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -427,8 +427,10 @@ public class NsisExecutable {
    * @return the size of the current section
    */
   private long getSectionSizeFromOffsets(int currentSectionOffset, int nextSectionOffset) {
-    if (currentSectionOffset == 0 || currentSectionOffset == this.firstHeader.inflatedHeaderSize) {
+    if (currentSectionOffset == 0) {
       return 0;
+    } else if (nextSectionOffset == 0) {
+      return this.firstHeader.inflatedHeaderSize - currentSectionOffset;
     }
     return nextSectionOffset - currentSectionOffset;
   }

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -39,17 +39,17 @@ public class NsisExecutable {
   public static final int FLAG_IS_COMPRESSED = 0x80000000;
 
   private BinaryReader reader;
+  private long headerOffset;
+  private long crcSignatureOffset;
   private NsisDecompressionProvider decompressionProvider;
   private NsisFirstHeader firstHeader;
   private NsisCommonHeader commonHeader;
   private NsisPage[] pages;
-  private long headerOffset;
   private NsisSection[] sections;
   private NsisEntry[] entries;
   private NsisStrings strings;
   private NsisLangTables langTables;
   private NsisControlColors ctlColors;
-  private long crcSignatureOffset;
 
   /**
    * Use createNsisExecutable to create a Nsis Executable object
@@ -427,10 +427,8 @@ public class NsisExecutable {
    * @return the size of the current section
    */
   private long getSectionSizeFromOffsets(int currentSectionOffset, int nextSectionOffset) {
-    if (currentSectionOffset == 0) {
+    if (currentSectionOffset == 0 || currentSectionOffset == this.firstHeader.inflatedHeaderSize) {
       return 0;
-    } else if (nextSectionOffset == 0) {
-      return this.crcSignatureOffset - currentSectionOffset; // Last section of the file
     }
     return nextSectionOffset - currentSectionOffset;
   }

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -20,6 +20,7 @@ import nsis.compression.NsisUncompressedProvider;
 import nsis.format.InvalidFormatException;
 import nsis.format.NsisBlockHeader;
 import nsis.format.NsisCommonHeader;
+import nsis.format.NsisControlColors;
 import nsis.format.NsisEntry;
 import nsis.format.NsisFirstHeader;
 import nsis.format.NsisLangTables;
@@ -47,6 +48,7 @@ public class NsisExecutable {
   private NsisEntry[] entries;
   private NsisStrings strings;
   private NsisLangTables langTables;
+  private NsisControlColors ctlColors;
 
   /**
    * Use createNsisExecutable to create a Nsis Executable object
@@ -112,6 +114,9 @@ public class NsisExecutable {
       this.langTables = new NsisLangTables(blockReader,
           this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset(),
           this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset());
+      this.ctlColors = new NsisControlColors(blockReader,
+          this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset(),
+          this.getBlockHeader(NsisConstants.BlockHeaderType.BACKGROUND_FONT.ordinal()).getOffset());
     }
   }
 
@@ -328,6 +333,16 @@ public class NsisExecutable {
   }
 
   /**
+   * Get the offset of the ctlColors section.
+   * 
+   * @return
+   */
+  public int getControlColorsOffset() {
+    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal())
+        .getOffset();
+  }
+
+  /**
    * Get the number of pages in the Nsis executable
    * 
    * @return the number of pages
@@ -401,5 +416,14 @@ public class NsisExecutable {
    */
   public int getLangTablesSectionSize() {
     return this.langTables.getLangTablesSectionLength();
+  }
+
+  /**
+   * Get the size of the ctlColors section of the NSIS executable
+   * 
+   * @return
+   */
+  public int getControlColorsSectionSize() {
+    return this.ctlColors.getControlColorsSectionLength();
   }
 }

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -112,9 +112,7 @@ public class NsisExecutable {
       this.entries = getEntries(blockReader);
       initStrings(blockReader);
       initLangTables(blockReader);
-      this.ctlColors = new NsisControlColors(blockReader,
-          this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset(),
-          this.getBlockHeader(NsisConstants.BlockHeaderType.BACKGROUND_FONT.ordinal()).getOffset());
+      initCtlColors(blockReader);
     }
   }
 
@@ -204,6 +202,20 @@ public class NsisExecutable {
         this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset(),
         this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset());
     this.langTables = new NsisLangTables(reader, langTablesSectionLength);
+  }
+
+  /**
+   * Initializes the ctlColors section. After passing through this function, the BinaryReader's
+   * index will be at the end of the ctlColors section.
+   * 
+   * @param reader
+   */
+  private void initCtlColors(BinaryReader reader) {
+    reader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.CONTROL_COLORS));
+    long ctlColorsSectionLength = getSectionSizeFromOffsets(
+        this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset(),
+        this.getBlockHeader(NsisConstants.BlockHeaderType.BACKGROUND_FONT.ordinal()).getOffset());
+    this.ctlColors = new NsisControlColors(reader, ctlColorsSectionLength);
   }
 
   private long findHeaderOffset() throws IOException, InvalidFormatException {
@@ -399,7 +411,7 @@ public class NsisExecutable {
    * 
    * @return
    */
-  public int getControlColorsSectionSize() {
+  public long getControlColorsSectionSize() {
     return this.ctlColors.getControlColorsSectionLength();
   }
 

--- a/nsis/src/nsis/file/NsisExecutable.java
+++ b/nsis/src/nsis/file/NsisExecutable.java
@@ -48,11 +48,8 @@ public class NsisExecutable {
   private NsisEntry[] entries;
   private NsisStrings strings;
   private NsisLangTables langTables;
-<<<<<<< HEAD
   private NsisControlColors ctlColors;
-=======
   private long crcSignatureOffset;
->>>>>>> origin/master
 
   /**
    * Use createNsisExecutable to create a Nsis Executable object
@@ -113,21 +110,11 @@ public class NsisExecutable {
       this.sections = getSections(blockReader);
       blockReader.setPointerIndex(this.getSectionOffset(NsisConstants.BlockHeaderType.ENTRIES));
       this.entries = getEntries(blockReader);
-<<<<<<< HEAD
-      blockReader.setPointerIndex(this.getStringsOffset());
-      this.strings = new NsisStrings(blockReader,
-          this.getBlockHeader(NsisConstants.BlockHeaderType.STRINGS.ordinal()).getOffset(),
-          this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset());
-      this.langTables = new NsisLangTables(blockReader,
-          this.getBlockHeader(NsisConstants.BlockHeaderType.LANGTABLES.ordinal()).getOffset(),
-          this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset());
+      initStrings(blockReader);
+      initLangTables(blockReader);
       this.ctlColors = new NsisControlColors(blockReader,
           this.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal()).getOffset(),
           this.getBlockHeader(NsisConstants.BlockHeaderType.BACKGROUND_FONT.ordinal()).getOffset());
-=======
-      initStrings(blockReader);
-      initLangTables(blockReader);
->>>>>>> origin/master
     }
   }
 
@@ -332,16 +319,6 @@ public class NsisExecutable {
   }
 
   /**
-   * Get the offset of the ctlColors section.
-   * 
-   * @return
-   */
-  public int getControlColorsOffset() {
-    return this.commonHeader.getBlockHeader(NsisConstants.BlockHeaderType.CONTROL_COLORS.ordinal())
-        .getOffset();
-  }
-
-  /**
    * Get the number of pages in the Nsis executable
    * 
    * @return the number of pages
@@ -418,14 +395,15 @@ public class NsisExecutable {
   }
 
   /**
-<<<<<<< HEAD
    * Get the size of the ctlColors section of the NSIS executable
    * 
    * @return
    */
   public int getControlColorsSectionSize() {
     return this.ctlColors.getControlColorsSectionLength();
-=======
+  }
+
+  /**
    * Get the section size from the section's start offset and the next section's start offset. If
    * the next section's start offset is 0, it calculates the size using the CRC signature offset,
    * meaning that the section is the last section of the file before the CRC bytes. If the current
@@ -443,6 +421,5 @@ public class NsisExecutable {
       return this.crcSignatureOffset - currentSectionOffset; // Last section of the file
     }
     return nextSectionOffset - currentSectionOffset;
->>>>>>> origin/master
   }
 }

--- a/nsis/src/nsis/format/NsisControlColors.java
+++ b/nsis/src/nsis/format/NsisControlColors.java
@@ -1,0 +1,24 @@
+package nsis.format;
+
+import ghidra.app.util.bin.BinaryReader;
+
+public class NsisControlColors {
+  private int sectionLength;
+
+  /**
+   * When creating a NsisControlColors object, the pointer of the reader is advanced to the end of
+   * the controlColors section.
+   * 
+   * @param reader
+   * @param sectionStartOffset
+   * @param sectionEndOffset
+   */
+  public NsisControlColors(BinaryReader reader, int sectionStartOffset, int sectionEndOffset) {
+    this.sectionLength = Math.abs(sectionEndOffset - sectionStartOffset);
+    reader.setPointerIndex(reader.getPointerIndex() + this.sectionLength);
+  }
+
+  public int getControlColorsSectionLength() {
+    return this.sectionLength;
+  }
+}

--- a/nsis/src/nsis/format/NsisControlColors.java
+++ b/nsis/src/nsis/format/NsisControlColors.java
@@ -3,7 +3,7 @@ package nsis.format;
 import ghidra.app.util.bin.BinaryReader;
 
 public class NsisControlColors {
-  private int sectionLength;
+  private long sectionLength;
 
   /**
    * When creating a NsisControlColors object, the pointer of the reader is advanced to the end of
@@ -13,12 +13,12 @@ public class NsisControlColors {
    * @param sectionStartOffset
    * @param sectionEndOffset
    */
-  public NsisControlColors(BinaryReader reader, int sectionStartOffset, int sectionEndOffset) {
-    this.sectionLength = Math.abs(sectionEndOffset - sectionStartOffset);
+  public NsisControlColors(BinaryReader reader, long sectionLength) {
+    this.sectionLength = sectionLength;
     reader.setPointerIndex(reader.getPointerIndex() + this.sectionLength);
   }
 
-  public int getControlColorsSectionLength() {
+  public long getControlColorsSectionLength() {
     return this.sectionLength;
   }
 }

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -78,7 +78,7 @@ public class NsisExecutableTest {
       assertEquals(0xc2, ne.getLangTablesSectionSize());
 
       // CtlColors
-      assertEquals(0x8e20, ne.getControlColorsSectionSize());
+      assertEquals(0x0, ne.getControlColorsSectionSize());
     }
   }
 
@@ -136,7 +136,7 @@ public class NsisExecutableTest {
       assertEquals(0xc2, ne.getLangTablesSectionSize());
 
       // CtlColors
-      assertEquals(0x81b1, ne.getControlColorsSectionSize());
+      assertEquals(0x0, ne.getControlColorsSectionSize());
     }
   }
 
@@ -195,7 +195,7 @@ public class NsisExecutableTest {
       assertEquals(0xc2, ne.getLangTablesSectionSize());
 
       // CtlColors
-      assertEquals(0x8e20, ne.getControlColorsSectionSize());
+      assertEquals(0x0, ne.getControlColorsSectionSize());
     }
   }
 
@@ -254,7 +254,7 @@ public class NsisExecutableTest {
       assertEquals(0xc2, ne.getLangTablesSectionSize());
 
       // CtlColors
-      assertEquals(0x8e20, ne.getControlColorsSectionSize());
+      assertEquals(0x0, ne.getControlColorsSectionSize());
     }
   }
 

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -76,6 +76,9 @@ public class NsisExecutableTest {
 
       // LangTables
       assertEquals(0xc2, ne.getLangTablesSectionSize());
+      
+      // CtlColors
+      assertEquals(0x7da, ne.getControlColorsSectionSize());
     }
   }
 

--- a/nsis/src/nsis/tests/NsisExecutableTest.java
+++ b/nsis/src/nsis/tests/NsisExecutableTest.java
@@ -76,9 +76,9 @@ public class NsisExecutableTest {
 
       // LangTables
       assertEquals(0xc2, ne.getLangTablesSectionSize());
-      
+
       // CtlColors
-      assertEquals(0x7da, ne.getControlColorsSectionSize());
+      assertEquals(0x8e20, ne.getControlColorsSectionSize());
     }
   }
 
@@ -134,6 +134,9 @@ public class NsisExecutableTest {
 
       // LangTables
       assertEquals(0xc2, ne.getLangTablesSectionSize());
+
+      // CtlColors
+      assertEquals(0x81b1, ne.getControlColorsSectionSize());
     }
   }
 
@@ -190,6 +193,9 @@ public class NsisExecutableTest {
 
       // LangTables
       assertEquals(0xc2, ne.getLangTablesSectionSize());
+
+      // CtlColors
+      assertEquals(0x8e20, ne.getControlColorsSectionSize());
     }
   }
 
@@ -246,6 +252,9 @@ public class NsisExecutableTest {
 
       // LangTables
       assertEquals(0xc2, ne.getLangTablesSectionSize());
+
+      // CtlColors
+      assertEquals(0x8e20, ne.getControlColorsSectionSize());
     }
   }
 


### PR DESCRIPTION
Added the initialization of 'control colors' section and fixed the section length calculations for compressed files (I now use inflated header size instead of the offset of the CRC signature)

- [ x] Tests pass
